### PR TITLE
feat: AUTOSIGN_GPG_LOCAL_FPR: selection of local signer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,7 @@ check:
 		exit 1; \
 	}
 	+$(MAKE) clean
-	umask 077 && mkdir -p gnupghome
-	[ -n '${AUTOSIGN_NO_SEND_KEYS}' ] || echo 'keyserver $(LOCAL_KEYSERVER)' > gnupghome/gpg.conf
-	@echo Generating authority key ...
-	GNUPGHOME=$${PWD}/gnupghome gpg --batch --passphrase '' --quick-gen-key 'Testing Authority Key'
-	@echo Performing the initial run ...
-	GNUPGHOME=$${PWD}/gnupghome bash ./autosign.bash
-	@echo Performing the verification run ...
-	GNUPGHOME=$${PWD}/gnupghome bash ./autosign.bash
+	bash test.bash
 
 clean:
 	rm -rf gnupghome ldap.txt signed.txt to-send.txt

--- a/autosign.bash
+++ b/autosign.bash
@@ -1,25 +1,43 @@
 #!/usr/bin/env bash
 # Authority key autosigning script
-# (c) 2019 Michał Górny
-# 2-clause BSD license
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: 2019 Michał Górny
+# SPDX-FileCopyrightText: 2023 Robin Johnson
+
+: "${KEYRING_URL:=https://qa-reports.gentoo.org/output/active-devs.gpg}"
+: "${AUTOSIGN_FILTER:=(gentooStatus=active)}"
+
+# Used for trust args to gpg calls
+export -a trust_args
+
+# Baseline GPG
+gpgcmd=(
+	gpg -q --no-auto-check-trustdb
+)
+
+warn() {
+	echo "${@}" >&2
+}
 
 die() {
-	echo "${@}" >&2
+	warn "${@}"
 	exit 1
 }
 
 # Import key updates.
 refresh_keys() {
 	# we trust qa-scripts to refresh them for us
-	wget -q -O - https://qa-reports.gentoo.org/output/active-devs.gpg |
-		gpg -q --import || die "Failed to refresh keys"
+	wget -q -O keyring.gpg "${KEYRING_URL}" || die "Failed to fetch keyring"
+	gpg -q --import keyring.gpg || die "Failed to import keyring"
 }
 
 # Get UID-fingerprint mapping from LDAP, for active devs.
 get_ldap() {
-	local l uid= fpr system
+	local l uid='' fpr='' system=''
+	local f='ldapraw.txt'
+	get_ldap_raw >"${f}"
 	while read l; do
-		case ${l} in
+		case "${l}" in
 			'dn: uid='*',ou=devs,dc=gentoo,dc=org')
 				uid=${l#dn: uid=}
 				uid=${uid%%,*}
@@ -48,47 +66,124 @@ get_ldap() {
 				die "Unknown LDAP data: ${l}"
 				;;
 		esac
-	done < <(ldapsearch -Z -D '' -LLL "${AUTOSIGN_FILTER:-(gentooStatus=active)}" gpgfingerprint ||
-		die "LDAP query failed")
+	done <"${f}"
+}
+
+get_ldap_raw() {
+	h="$(hostname --fqdn)"
+	# This needs some weird quoting because SSH.
+	if [[ "${h%.gentoo.org}" == "${h}" ]]; then
+		ssh dev.gentoo.org "ldapsearch -Z -D '' -LLL '${AUTOSIGN_FILTER}' gpgfingerprint"
+		rc=$?
+	else
+		ldapsearch -Z -D '' -LLL "${AUTOSIGN_FILTER}" gpgfingerprint
+		rc=$?
+	fi
+	[[ $rc -ne 0 ]] && die "LDAP query failed"
 }
 
 # Get UID-fingerprint list of all currently trusted keys.
 get_signed_keys() {
-	local l keyid= fpr= trust uid email
+	local -a GPGREC
+	local l keyid='' fpr=''
+	local uid_validity='' uid_string='' uid_email=''
+	#local sig_validity= sig_class= sig_issuer=
+
+	op=list-keys
+	#op=check-sigs
+
+	local f=${op}.txt
+	gpg --with-colons "${trust_args[@]}" --${op} >${f}
+
 	while read l; do
-		case ${l} in
+		# split the gpg line correctly into fields
+		# Per GPG DETAILS, there will never be a raw : inside a field, it will instead be encoded as \x3a
+		# TODO: as a seperate pass, apply a C decode to convert the above back.
+		IFS=':' read -ra GPGREC <<< "$l"
+
+		# Be a terrible programmer: the docs have fields numbered from 1
+		# So shift up the entire array by one position
+		i=${#GPGREC[@]}
+		while [[ $i -ge 0 ]]; do
+			GPGREC[i+1]="${GPGREC[i]}"
+			let i=i-1
+		done
+		GPGREC[0]='INVALID'
+
+		case ${GPGREC[1]} in
 			# start of new key
-			pub:*)
-				keyid=${l#pub:*:*:*:}
-				keyid=${keyid%%:*}
+			pub)
+				keyid=${GPGREC[5]}
 				fpr=
+				uid_validity=
+				uid_string=
+				uid_email=
+				#sig_validity=
+				#sig_class=
+				#sig_issuer=
 				[[ -n ${keyid} ]] || die "Unable to parse keyid: ${l}"
 				;;
 			# fingerprint, should follow pub: immediately
-			fpr:*)
+			fpr)
 				# skip if we already got one (subkeys)
 				[[ -n ${fpr} ]] && continue
-				fpr=${l#fpr:::::::::}
-				fpr=${fpr%%:*}
+				fpr=${GPGREC[10]}
 				[[ -n ${fpr} ]] || die "Unable to parse fpr: ${l}"
-				[[ ${fpr:(-16)} == ${keyid} ]] ||
+				[[ ${fpr:(-16)} == "${keyid}" ]] ||
 					die "fpr/keyid mismatch: ${fpr} / ${keyid}"
 				;;
-			uid:*)
+			uid)
 				[[ -n ${fpr} ]] || die "UID without fpr: ${l}"
-				trust=${l#uid:}
-				uid=${trust#?::::*::*::}
-				trust=${trust%%:*}
-				uid=${uid%%:*}
-				email=${uid#*<}
-				email=${email%%>*}
-				[[ -n ${trust} && -n ${email} ]] ||
-					die "Unable to parse uid: ${l}"
-				[[ ${trust} == f ]] &&
-					printf "%s\t%s\n" "${email,,}" "${fpr}"
+				# Start of a new uid means any old sig is not applicable.
+				#sig_validity=
+				#sig_class=
+				#sig_issuer=
+				# Parse the uid
+				uid_validity=${GPGREC[2]}
+				uid_string=${GPGREC[10]}
+				uid_email=${uid_string#*<}
+				uid_email=${uid_email%%>*}
+				if [[ -z ${uid_validity} ]] || [[ -z ${uid_email} ]]; then
+					warn "Unable to parse uid: ${l}"
+					continue
+				fi
+				# The uid validity *should* be 'f' if the signature is present.
+				[[ ${uid_validity} != f ]] && continue
+				[[ ${op} == list-keys ]] && printf "%s\t%s\n" "${uid_email,,}" "${fpr}"
 				;;
+			# TODO: for use with check-sigs
+			# Sig will always follow uids, but is only present if we make this be --check-sigs
+			#sig)
+			#	[[ -n ${fpr} ]] || die "sig without fpr: ${l}"
+			#	[[ -n ${uid_email} ]] || die "sig without uid: ${l}"
+			#	sig_validity=${GPGREC[2]}
+			#	sig_class=${GPGREC[11]}
+			#	sig_issuer=${GPGREC[13]}
+			#	# Skip invalid signatures
+			#	[[ ${sig_validity} != "!" ]] && continue
+			#	# Skip other signature classes
+			#	# 1[0123]x => match a subset of RFC4880 signatures
+			#	# x = must be exportable
+			#	# 0x10 = generic
+			#	# 0x11 = persona
+			#	# 0x12 = casual
+			#	# 0x13 = positive
+			#	# https://datatracker.ietf.org/doc/html/rfc4880#section-5.2.1
+			#	# TODO: right now this code sets code 0x10 (generic),
+			#	# whereas 0x11 Persona might be more applicable in future.
+			#	case ${sig_class} in
+			#		1[0123]x) ;;
+			#		*) continue ;;
+			#	esac
+			#	# Skip signatures from another issuer
+			#	[ ${sig_issuer} != ${AUTOSIGN_GPG_LOCAL_FPR} ] && continue
+
+			#	# good signature at this point.
+			#	printf "%s\t%s\n" "${uid_email,,}" "${fpr}"
+			#	;;
 		esac
-	done < <(gpg --with-colons --list-keys)
+	# Checking the signatures is important, don't just get a list of them.
+	done <"${f}"
 }
 
 # Revoke the specified UID signature.
@@ -96,35 +191,16 @@ get_signed_keys() {
 revoke_sig() {
 	local key=${1}
 	local uid=${2}
+	local _gpgcmd=( "${gpgcmd[@]}" )
+	_gpgcmd+=( "${trust_args[@]}" )
 
 	echo "${uid}: Revoking signature on key ${key}"
-	# TODO: support revoking only one uid?
-	# (NB: will this ever happen?)
-	timeout 60 expect - <<-EOF || die "revoking signature failed"
-		spawn gpg --edit-key ${key}
-		expect "gpg>"
-		send "revsig\n"
-		while (1) {
-			expect {
-				"Create a revocation certificate for this signature?"
-					{ send "y\n" }
-				"Are you sure you still want to revoke it?"
-					{ send "n\n" }
-				"Really create the revocation certificates?"
-					break
-			}
-		}
-		send "y\n"
-		expect "Your decision?"
-		send "4\n"
-		expect ">"
-		send "\n"
-		expect "Is this okay?"
-		send "y\n"
-		expect "gpg>"
-		send "save\n"
-		expect eof
-	EOF
+	"${_gpgcmd[@]}" \
+		-q \
+		--quick-revoke-sig \
+		"${key}" \
+		"${AUTOSIGN_GPG_LOCAL_FPR}" \
+		"${uid}"
 }
 
 # Sign the specified UID on specified key.
@@ -134,30 +210,51 @@ sign_key() {
 	local sign_uid=${2}
 	local ret=1
 
+	local f=sign-key-${key}.txt
+
+	"${gpgcmd[@]}" \
+		"${trust_args[@]}" \
+		--with-colons \
+		--list-keys "${key}" \
+		2>/dev/null >"${f}"
+
 	# verify whether the key is suitable for signing
 	local l trust uid email uids=() need_full=0
 	while read l; do
-		case ${l} in
-			pub:[er]:*)
+		# split the gpg line correctly into fields
+		# Per GPG DETAILS, there will never be a raw : inside a field, it will instead be encoded as \x3a
+		# TODO: as a seperate pass, apply a C decode to convert the above back.
+		IFS=':' read -ra GPGREC <<< "$l"
+
+		# Be a terrible programmer: the docs have fields numbered from 1
+		# So shift up the entire array by one position
+		i=${#GPGREC[@]}
+		while [[ $i -ge 0 ]]; do
+			GPGREC[i+1]="${GPGREC[i]}"
+			let i=i-1
+		done
+		GPGREC[0]='INVALID'
+
+		case ${GPGREC[1]} in
+			pub)
 				# skip expired key
-				return 1
+				# skip revoked key
+				[[ ${GPGREC[2]} =~ [er] ]] && return 1
 				;;
-			uid:*)
-				trust=${l#uid:}
-				uid=${trust#?::::*::*::}
-				trust=${trust%%:*}
-				uid=${uid%%:*}
+			uid)
+				trust=${GPGREC[2]}
+				uid=${GPGREC[10]}
 				email=${uid#*<}
 				email=${email%%>*}
 				[[ -n ${trust} && -n ${email} ]] ||
 					die "Unable to parse uid: ${l}"
-				[[ ${email,,} == ${sign_uid,,} && ${trust} != [er] ]] &&
+				[[ "${email,,}" == "${sign_uid,,}" && ${trust} != [er] ]] &&
 					uids+=( "=${uid}" )
 				# if there are revoked UIDs, they may collide
-				[[ ${trust} == [er] ]] && need_full=1
+				[[ ${trust} =~ [er] ]] && need_full=1
 				;;
 		esac
-	done < <(gpg --no-auto-check-trustdb --with-colons --list-keys "${key}" 2>/dev/null)
+	done <"${f}"
 
 	if [[ ${#uids[@]} -eq 0 ]]; then
 #		echo "${sign_uid}: no @g.o UID (${key})"
@@ -171,13 +268,48 @@ sign_key() {
 
 	echo "${sign_uid}: signing new key ${key}"
 	for uid in "${uids[@]}"; do
-		gpg --no-auto-check-trustdb \
+		"${gpgcmd[@]}" \
 			--cert-policy-url https://www.gentoo.org/glep/glep-0079.html \
 			--default-cert-expire 1y \
+			"${trust_args[@]}" \
+			--quiet --batch --no-tty \
 			--quick-sign-key "${key}" "${uid}" && ret=0
 	done
 
 	return "${ret}"
+}
+
+get_localuser_fpr() {
+	local fpr seen_sec=0
+	local f=secret-keys.txt
+
+	"${gpgcmd[@]}" --with-colons --list-secret-keys >${f}
+
+	while read l; do
+		# split the gpg line correctly into fields
+		# Per GPG DETAILS, there will never be a raw : inside a field, it will instead be encoded as \x3a
+		# TODO: as a seperate pass, apply a C decode to convert the above back.
+		IFS=':' read -ra GPGREC <<< "$l"
+		# Be a terrible programmer: the docs have fields numbered from 1
+		# So shift up the entire array by one position
+		i=${#GPGREC[@]}
+		while [[ $i -ge 0 ]]; do
+			GPGREC[i+1]="${GPGREC[i]}"
+			let i=i-1
+		done
+		GPGREC[0]='INVALID'
+
+		case ${GPGREC[1]} in
+			sec) fpr='' ; let seen_sec=seen_sec+1 ;;
+			fpr) fpr=${GPGREC[10]} ;;
+		esac
+	done <"${f}"
+	case "$seen_sec" in
+		0) die "No secret keys present for authority signing, is GNUPGHOME correct?" ;;
+		1) echo "$fpr" ;;
+		*) die "Multiple secret keys present for authority signing, specify correct key with AUTOSIGN_GPG_LOCAL_FPR" ;;
+	esac
+	return 0
 }
 
 main() {
@@ -186,32 +318,88 @@ main() {
 	# avoid running with old agent
 	gpgconf --kill all
 
+	if [[ -n "${AUTOSIGN_TMPDIR}" ]]; then
+		TMPDIR=${AUTOSIGN_TMPDIR}
+		mkdir -p "${TMPDIR}"
+		: "${CLEANUP_TMPDIR:=0}"
+	else
+		TMPDIR=$(mktemp -d)
+		: "${CLEANUP_TMPDIR:=1}"
+	fi
+	# Setup the cleaning.
+	if [[ $CLEANUP_TMPDIR -eq 1 ]]; then
+		trap "rm -rf $TMPDIR" INT TERM EXIT
+	else
+		echo "TMPDIR is at $TMPDIR with cleanup disabled"
+	fi
+
+	export TMPDIR
+	cd "$TMPDIR" || die "Failed to setup unique TMPDIR"
+
+	# A trusted user was NOT specified. So check the keyring and find it.
+	if [[ -z "${AUTOSIGN_GPG_LOCAL_FPR}" ]]; then
+		AUTOSIGN_GPG_LOCAL_FPR=$(get_localuser_fpr)
+	fi
+	[[ -z "${AUTOSIGN_GPG_LOCAL_FPR}" ]] && die "Failed to find fingerprint for local key to sign with"
+
+	# If the key ends with a ! it's special GPG syntax for subkeys
+	# We need it for local-user, but not other fields
+	_AUTOSIGN_GPG_LOCAL_FPR=${AUTOSIGN_GPG_LOCAL_FPR%!}
+	trustdb=trustdb-${_AUTOSIGN_GPG_LOCAL_FPR}
+	# Explicitly remove the trustdb, as we will re-calculate it.
+	rm -f "$trustdb"
+	# If an explicit local user was set, ignore all other keys for calculating
+	# trust.
+	#
+	# do it specifically by creating a new trustdb for that localkey, and
+	# setting only that localkey to trusted in the trustdb.
+	#
+	# The local user MUST be specified as a full fingerprint, for matching &
+	# security reasons.
+	trust_args=(
+		--trust-model pgp
+		--trusted-key "${_AUTOSIGN_GPG_LOCAL_FPR}"
+		--trustdb-name "${trustdb}"
+		--local-user "${AUTOSIGN_GPG_LOCAL_FPR}"
+		--default-key "${AUTOSIGN_GPG_LOCAL_FPR}"
+	)
+
 	refresh_keys
+
+	# Check the trustdb now that we have imported the keys.
+	"${gpgcmd[@]}" -q --check-trustdb
+
 	get_ldap | sort -u > ldap.txt || die 'failure writing ldap.txt'
 	get_signed_keys | sort -u > signed.txt || die 'failure writing signed.txt'
 
+	# Items ONLY in ldap => need to sign
+	comm -13 signed.txt ldap.txt >to-sign.txt
+	# Items ONLY in signed => need to revoke
+	comm -23 signed.txt ldap.txt >to-revoke.txt
+
 	local k uid
 	# revoke signatures on old keys
-	while read uid k; do
+	while IFS=$(printf '\t') read uid k; do
+		echo "revoke_sig '${k}' '${uid}'"
 		if revoke_sig "${k}" "${uid}"; then
 			echo "${k}" >> to-send.txt || die 'failure writing to-send.txt'
 		fi
-	done < <(comm -23 signed.txt ldap.txt)
+	done < to-revoke.txt
 
 	# sign new keys
-	while read uid k; do
+	while IFS=$(printf '\t') read uid k; do
 		if sign_key "${k}" "${uid}"; then
 			echo "${k}" >> to-send.txt || die 'failure writing to-send.txt'
 		fi
-	done < <(comm -13 signed.txt ldap.txt)
+	done < to-sign.txt
 
-	gpg -q --check-trustdb
+	"${gpgcmd[@]}" -q --check-trustdb
 
 	if [[ ! ${AUTOSIGN_NO_SEND_KEYS} ]]; then
 		# send key updates to the keyserver
 		local retries=0
 		while [[ -s to-send.txt ]]; do
-			if gpg --send-keys $(head -n 10 to-send.txt); then
+			if gpg "${trust_args[@]}" --send-keys $(head -n 10 to-send.txt); then
 				tail -n +11 to-send.txt > to-send.txt.tmp &&
 				mv to-send.txt.tmp to-send.txt || die 'failure writing to-send.txt'
 			else

--- a/test.bash
+++ b/test.bash
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Authority key autosigning testcases
+# SPDX-License-Identifier: BSD-2-Clause
+# SPDX-FileCopyrightText: 2019 Michał Górny
+# SPDX-FileCopyrightText: 2023 Robin Johnson
+if [ -z "$LOCAL_KEYSERVER" ] && [ -z "${AUTOSIGN_NO_SEND_KEYS}" ] ; then
+	echo "Please set LOCAL_KEYSERVER to local keyserver address for pushing,"; 1>&2
+	echo "or AUTOSIGN_NO_SEND_KEYS=1 to disable pushing."; 1>&2
+	exit 1;
+fi
+
+TEST_RC=0
+
+# For testing, keep a single tmpdir, and iterate phases.
+export AUTOSIGN_TMPDIR=$(mktemp -d /tmp/autosign-test.XXXXXX)
+export GNUPGHOME=$AUTOSIGN_TMPDIR/gnupghome
+echo "Testing tmpdir is $AUTOSIGN_TMPDIR"
+
+umask 077 && mkdir -p $GNUPGHOME
+[ -n "${AUTOSIGN_NO_SEND_KEYS}" ] || echo "keyserver ${LOCAL_KEYSERVER}" > ${GNUPGHOME}/gpg.conf
+
+# This is a complete hack.
+DO_REVOKE_TEST=0
+if [[ -z "${AUTOSIGN_FILTER}" ]]; then
+	: "${AUTOSIGN_FILTER:=(&(gentooStatus=active)(gpgfingerprint=*))}"
+	DO_REVOKE_TEST=1
+	# All devs
+	FILTER_00="${AUTOSIGN_FILTER}"
+	# Exclude a few devs to trigger revoke.
+	FILTER_01="(&${AUTOSIGN_FILTER}(!(uid=a*)))"
+	AUTOSIGN_FILTER=$FILTER_00
+	export AUTOSIGN_FILTER
+fi
+
+authuid_foo='Testing Authority Key Foo <auth-foo@example.com>'
+authuid_bar='Testing Authority Key Bar <auth-bar@example.com>'
+
+echo "Generating dummy keys (set 1)..."
+# this is to ensure there are other secret keys, and we aren't just lucky with the
+# code picking a random key that was the correct one for the key.
+for f in $(seq 1 4) ; do
+	:
+	#gpg --batch --passphrase '' --quick-gen-key "Dummy Key 0x$(printf %04x $f)"
+done
+
+echo "Generating authority keys ..."
+gpg -q --batch --passphrase '' --quick-gen-key "${authuid_foo}"
+authfpr_foo=$(
+	gpg --with-colon --list-secret-keys "${authuid_foo}" |awk -F: '($1 == "sec"){sec_k=$5 }($1 == "fpr"){fpr=$10; r= sec_k "$" ; if(match(fpr, r)){ print fpr}}'
+)
+
+gpg -q --batch --passphrase '' --quick-gen-key "${authuid_bar}"
+authfpr_bar=$(
+	gpg --with-colon --list-secret-keys "${authuid_bar}" |awk -F: '($1 == "sec"){sec_k=$5 }($1 == "fpr"){fpr=$10; r= sec_k "$" ; if(match(fpr, r)){ print fpr}}'
+)
+
+echo "Generating dummy keys (set 2)..."
+# this is to ensure there are other secret keys, and we aren't just lucky with the
+# code picking a random key that was the correct one for the key.
+for f in $(seq 5 8) ; do
+	:
+	#gpg --batch --passphrase '' --quick-gen-key "Dummy Key <dummy-0x$(printf %04x $f)@example.com>"
+done
+
+if [[ -z "$authfpr_foo" ]] || [[ -z "$authfpr_bar" ]] || [ "$authfpr_bar" == "$authfpr_foo" ]; then
+	echo "Failed to generate 2 distinct authority keys" 1>&2
+	exit 1
+fi
+
+#echo "Showing all secret keys"
+#gpg --list-secret-keys
+
+
+echo "Performing the initial runs, for keys foo & bar ..."
+n=00
+gpg --with-colons --check-sig \
+	--trusted-key ${authfpr_foo} \
+	--trusted-key ${authfpr_bar} \
+	>"${AUTOSIGN_TMPDIR}"/verification-${n}.txt
+AUTOSIGN_TMPDIR=${AUTOSIGN_TMPDIR}/${n}-foo/ AUTOSIGN_GPG_LOCAL_FPR=${authfpr_foo} bash ./autosign.bash
+AUTOSIGN_TMPDIR=${AUTOSIGN_TMPDIR}/${n}-bar/ AUTOSIGN_GPG_LOCAL_FPR=${authfpr_bar} bash ./autosign.bash
+
+echo "Performing the verification run ... - should be no new signatures"
+n=01
+gpg --with-colons --check-sig \
+	--trusted-key ${authfpr_foo} \
+	--trusted-key ${authfpr_bar} \
+	>"${AUTOSIGN_TMPDIR}"/verification-${n}.txt
+AUTOSIGN_TMPDIR=${AUTOSIGN_TMPDIR}/${n}-foo/ AUTOSIGN_GPG_LOCAL_FPR=${authfpr_foo} bash ./autosign.bash
+AUTOSIGN_TMPDIR=${AUTOSIGN_TMPDIR}/${n}-bar/ AUTOSIGN_GPG_LOCAL_FPR=${authfpr_bar} bash ./autosign.bash
+
+n=02
+gpg --with-colons --check-sig \
+	--trusted-key ${authfpr_foo} \
+	--trusted-key ${authfpr_bar} \
+	>"${AUTOSIGN_TMPDIR}"/verification-${n}.txt
+
+echo "Verification test: If this output is NOT identical, something changed:"
+diff -NuarwbB -I '^tru'  "${AUTOSIGN_TMPDIR}"/verification-{01,02}.txt
+rc=$?
+[[ $rc -ne 0 ]] && echo "Verification: FAIL - Something changed after verification pass" && TEST_RC=1
+[[ $rc -eq 0 ]] && echo "Verification: PASS"
+
+[[ $DO_REVOKE_TEST -eq 0 ]] && exit 0
+AUTOSIGN_FILTER=$FILTER_01
+export AUTOSIGN_FILTER
+
+echo "Performing the revocation run ... - should revoke some user"
+n=03
+gpg --with-colons --check-sig \
+	--trusted-key ${authfpr_foo} \
+	--trusted-key ${authfpr_bar} \
+	>"${AUTOSIGN_TMPDIR}"/verification-${n}.txt
+AUTOSIGN_TMPDIR=${AUTOSIGN_TMPDIR}/${n}-foo/ AUTOSIGN_GPG_LOCAL_FPR=${authfpr_foo} bash ./autosign.bash
+AUTOSIGN_TMPDIR=${AUTOSIGN_TMPDIR}/${n}-bar/ AUTOSIGN_GPG_LOCAL_FPR=${authfpr_bar} bash ./autosign.bash
+
+echo "Validating revocation"
+n=04
+gpg --with-colons --check-sig \
+	--trusted-key ${authfpr_foo} \
+	--trusted-key ${authfpr_bar} \
+	>"${AUTOSIGN_TMPDIR}"/verification-${n}.txt
+
+echo "Revocation compare: If this does NOT show output, then the revoke failed"
+# Check the developers starting with "a", who should have been revoked.
+diff -NuarwbB \
+	<(grep -E -e '^uid:.:.*\<a[0-9a-fA-Z.]+@gentoo.org' <"${AUTOSIGN_TMPDIR}"/verification-03.txt) \
+	<(grep -E -e '^uid:.:.*\<a[0-9a-fA-Z.]+@gentoo.org' <"${AUTOSIGN_TMPDIR}"/verification-04.txt) \
+	-I '^tru'
+rc=$?
+[[ $rc -ne 0 ]] && echo "FAIL - Revocation pass did not revoke..." && TEST_RC=1
+if [[ $rc -eq 0 ]]; then
+	grep -sq -E -e '^uid:[mfus]:.*\<a[0-9a-fA-Z.]+@gentoo.org' <"${AUTOSIGN_TMPDIR}"/verification-04.txt \
+		&& rc=1 \
+		&& echo "FAIL - Some uid=a* developer was still signed, when not expected..." \
+		&& TEST_RC=1
+fi
+[[ $rc -eq 0 ]] && echo "Revocation: PASS"
+
+exit $TEST_RC


### PR DESCRIPTION
Support selecting which local secret key should be used to sign other keys.

Via environment variable AUTOSIGN_GPG_LOCAL_FPR.

Under the hood, this uses gpg options: --local-user, --default-key, --trusted-key with distinct trustdb files per key.

It also supports revocation with the same configurable key.

The test suite is significantly enhanced to test revocation as well as
multiple keys.

Reference: https://bugs.gentoo.org/834329
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>
