### PR TITLE
autosign.bash: pass --force-sign-key in sign_key

### DIFF
--- a/autosign.bash
+++ b/autosign.bash
@@ -174,6 +174,7 @@ sign_key() {
 		gpg --no-auto-check-trustdb \
 			--cert-policy-url https://www.gentoo.org/glep/glep-0079.html \
 			--default-cert-expire 1y \
+			--force-sign-key \
 			--quick-sign-key "${key}" "${uid}" && ret=0
 	done
 


### PR DESCRIPTION
```
autosign.bash: pass --force-sign-key in sign_key

We had an infra incident where TLS certificates didn't get refreshed
and then the LDAP call returned nothing (so all keys had their signatures
revoked). But even once that was fixed, gpg wouldn't actually add
a new signature -- I think because the expiry time ended up being the
same as the one added earlier.

Per gpg's docs, we want --force-sign-key to update notation data.

For a bit more detail: gpg gave "Nothing to sign with key", and it
turns out that is controlled by:

  /* Fixme: see whether there is a revocation in which
   * case we should allow signing it again. */
  if (!node->pkt->pkt.signature->flags.exportable && local)
    tty_fprintf ( fp,
       _("\"%s\" was already locally signed by key %s\n"),
       user, keystr_from_pk (pk));
  else
    tty_fprintf (fp,
                _("\"%s\" was already signed by key %s\n"),
                user, keystr_from_pk (pk));

  if (opt.flags.force_sign_key
      || (opt.expert && !quick
          && cpr_get_answer_is_yes ("sign_uid.dupe_okay",
                                    _("Do you want to sign it "
                                      "again anyway? (y/N) "))))

Note the extremely relevant FIXME.

Signed-off-by: Sam James <sam@gentoo.org>
```