### PR TITLE
autosign.bash: add sanity check to not revoke all keys w/ bad LDAP co…

### DIFF
--- a/autosign.bash
+++ b/autosign.bash
@@ -191,6 +191,14 @@ main() {
 	get_ldap | sort -u > ldap.txt || die 'failure writing ldap.txt'
 	get_signed_keys | sort -u > signed.txt || die 'failure writing signed.txt'
 
+	if ! [[ -s ldap.txt ]] ; then
+		# Avoid revoking every key we trust if our LDAP query fails
+		# because of e.g. TLS certificate expiry or network issues.
+		if [[ ! ${AUTOSIGN_ALLOW_EMPTY_LDAP} ]]; then
+			die 'ldap search yielded no keys'
+		fi
+	fi
+
 	local k uid
 	# revoke signatures on old keys
 	while read uid k; do


### PR DESCRIPTION
…nnectivity

Followup to b3522cd57c12b2a1cf2b750a9dc18b0ff5a40f2a. Add a sanity check so we don't revoke every key we've signed in the case that our LDAP query fails and gives no results.

Set AUTOSIGN_ALLOW_EMPTY_LDAP to override this.